### PR TITLE
added license and readme file names in other langs

### DIFF
--- a/gitium/git-wrapper.php
+++ b/gitium/git-wrapper.php
@@ -50,6 +50,30 @@ wp-includes/
 /index.php
 /license.txt
 /readme.html
+
+# de_DE
+/liesmich.html
+
+# it_IT
+/LEGGIMI.txt
+/licenza.html
+
+# da_DK
+/licens.html
+
+# es_ES, es_PE
+/licencia.txt
+
+# hu_HU
+/licenc.txt
+/olvasdel.html
+
+# sk_SK
+/licencia-sk_SK.txt
+
+# sv_SE
+/licens-sv_SE.txt
+
 /wp-activate.php
 /wp-blog-header.php
 /wp-comments-post.php


### PR DESCRIPTION
I have searched http://i18n.svn.wordpress.org and have added all of the language specific readme and license files to the .gitignore file that's generated upon activating Gitium.
