### PR TITLE
fix container names in .drone.yml + wait for mysql

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,10 +1,13 @@
 build:
   test-gitium:
-    image: presslabs/php:$$PHP_VERSION
+    image: presslabs/pl-test-containers:php-$$PHP_VERSION
     commands:
       - bash bin/install-wp-tests.sh wordpress_test root root_pass 127.0.0.1 $$WP_VERSION
+      - dockerize --wait tcp://127.0.0.1:3306 -timeout 10s
       - make test
-
+    environment:
+      - WP_TESTS_DIR=/tmp/wordpress-tests-lib-$$WP_VERSION/
+      - WP_CORE_DIR=/tmp/wordpress-$$WP_VERSION/
 compose:
   database:
     image: mysql:5.5
@@ -14,6 +17,7 @@ compose:
 
 matrix:
   WP_VERSION:
+    - 3.9
     - 4.7.4
   PHP_VERSION:
     - 5.6

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,12 +4,16 @@ build:
     pull: true
     commands:
       - bash bin/install-wp-tests.sh wordpress_test root root_pass 127.0.0.1 $$WP_VERSION
-      - ./composer.phar install --dev
+      - ./composer.phar install --dev --no-progress
       - dockerize --wait tcp://127.0.0.1:3306 -timeout 10s
       - make test
     environment:
       - WP_TESTS_DIR=/tmp/wordpress-tests-lib-$$WP_VERSION/
       - WP_CORE_DIR=/tmp/wordpress-$$WP_VERSION/
+
+cache:
+  mount:
+    - vendor
 
 compose:
   database:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,7 @@
 build:
   test-gitium:
     image: presslabs/pl-test-containers:php-$$PHP_VERSION
+    pull: true
     commands:
       - bash bin/install-wp-tests.sh wordpress_test root root_pass 127.0.0.1 $$WP_VERSION
       - dockerize --wait tcp://127.0.0.1:3306 -timeout 10s

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,11 +4,13 @@ build:
     pull: true
     commands:
       - bash bin/install-wp-tests.sh wordpress_test root root_pass 127.0.0.1 $$WP_VERSION
+      - ./composer.phar install --dev
       - dockerize --wait tcp://127.0.0.1:3306 -timeout 10s
       - make test
     environment:
       - WP_TESTS_DIR=/tmp/wordpress-tests-lib-$$WP_VERSION/
       - WP_CORE_DIR=/tmp/wordpress-$$WP_VERSION/
+
 compose:
   database:
     image: mysql:5.5

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -38,7 +38,7 @@ else
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
 
-set -ex
+set -e
 
 install_wp() {
 


### PR DESCRIPTION
Now that the containers include wp testing components, the tests
start way faster so we need to wait for mysql.