### PR TITLE
Fixes array declared as string

### DIFF
--- a/gitium/gitium.php
+++ b/gitium/gitium.php
@@ -106,7 +106,7 @@ register_uninstall_hook( __FILE__, 'gitium_uninstall_hook' );
 
 ) */
 function gitium_update_versions() {
-	$new_versions = '';
+	$new_versions = [];
 
 	// get all themes from WP
 	$all_themes = wp_get_themes( array( 'allowed' => true ) );


### PR DESCRIPTION
PHP 7+ was throwing illegal offset warnings because of wrong variable declaration.