### PR TITLE
make Gitium Heroku/Dokku friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,61 @@ Gitium requires git command line tool with a minimum version of 1.7 installed on
 
 For more details about Gitium, head here: https://www.presslabs.org/gitium/docs/usage/
 
+### Working with Heroku / Dokku
+
+We recommend using a separate 'gitium' branch for automatic pushes from Gitium.
+
+Add a composer.json file to your root source folder, to save the original .gitignore that would otherwise be deleted by herokuish as
+part of deployment:
+```
+{
+    "scripts": {
+        "post-install-cmd": [
+            "cp .gitignore .gitignore_gitium"
+        ]
+    }
+}
+```
+
+Modify your .gitignore, to have at least the following lines:
+```
+*.log
+*.swp
+*.back
+*.bak
+*.sql
+*.sql.gz
+~*
+.maintenance
+wp-content/blogs.dir/
+wp-content/upgrade/
+wp-content/backup-db/
+wp-content/cache/
+wp-content/backups/
+wp-content/uploads/
+secret/
+**/node_modules/
+!wp-content/**/vendor/
+
+.heroku/
+.profile.d/
+vendor/
+.composer/
+.builders_run
+.bash_history
+.rnd
+.release
+.env
+*log.txt
+```
+
+The deployment process would consist of:
+
+1) Merge contents of 'gitium' branch into 'master', making sure merged contents are correct.
+
+2) Deploy with ```git push dokku``` as usual.
+
+
 ### Contributing
 
 We’ve built this to make our lives easier and we’re happy to do that for other developers, too. We’d really appreciate it if you could contribute with code, tests, documentation or just share your experience with Gitium.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ vendor/
 *log.txt
 ```
 
+Add this to your wp_config.php:
+```
+define( 'GITIUM_REMOTE_URL', <YOUR_REPO_URL>);
+define( 'GITIUM_REMOTE_TRACKING_BRANCH', 'gitium' );
+```
+
 The deployment process would consist of:
 
 1) Merge contents of 'gitium' branch into 'master', making sure merged contents are correct.

--- a/gitium/gitium.php
+++ b/gitium/gitium.php
@@ -51,6 +51,44 @@ require_once __DIR__ . '/inc/class-gitium-submenu-status.php';
 require_once __DIR__ . '/inc/class-gitium-submenu-commits.php';
 require_once __DIR__ . '/inc/class-gitium-submenu-settings.php';
 
+function gitium_auto_init( ) {
+	global $git;
+
+	error_log( __FUNCTION__ . ' -  in auto_init_all ' );
+
+	if ( ! $git->is_status_working() || ! $git->get_remote_url() || ! ! $git->get_remote_tracking_branch() ) {
+		$remote_url = get_option( 'gitium_remote_url', false );
+		$branch = get_transient( 'gitium_remote_tracking_branch' );
+		
+		error_log( __FUNCTION__ . ' -  $remote_url = ' . $remote_url );
+		error_log( __FUNCTION__ . ' -  $branch = ' . $branch );
+
+		if ( $remote_url && $branch ) {
+			$git->init();
+			$git->add_remote_url( $remote_url );
+			$git->fetch_ref();
+			$git->add();
+			$current_user = wp_get_current_user();
+			$commit = $git->commit( __( 'Merged existing code from ', 'gitium' ) . get_home_url(), $current_user->display_name, $current_user->user_email );
+			if ( ! $commit ) {
+				$git->cleanup();
+				error_log( __FUNCTION__ . ' -  Error commiting existing code' );
+				return;
+			}
+			if ( ! $git->merge_initial_commit( $commit, $branch ) ) {
+				error_log( __FUNCTION__ . ' -  Error merging existing code' );
+				$git->cleanup();
+				return;
+			}
+			$git->push( $branch );		
+
+			_gitium_status( true );
+			gitium_update_is_status_working();
+		}
+	}
+}
+add_action( 'wp_loaded', 'gitium_auto_init' );
+
 function gitium_load_textdomain() {
 	load_plugin_textdomain( 'gitium', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 }

--- a/gitium/gitium.php
+++ b/gitium/gitium.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Gitium
- * Version: 1.0.1
+ * Version: 1.0.3
  * Author: Presslabs
  * Author URI: https://www.presslabs.com
  * License: GPL2
@@ -54,14 +54,14 @@ require_once __DIR__ . '/inc/class-gitium-submenu-settings.php';
 function gitium_auto_init( ) {
 	global $git;
 
-	error_log( __FUNCTION__ . ' -  in auto_init_all ' );
+	// error_log( __FUNCTION__ . ' -  in auto_init_all ' );
 
 	if ( ! $git->is_status_working() || ! $git->get_remote_url() || ! ! $git->get_remote_tracking_branch() ) {
 		$remote_url = get_option( 'gitium_remote_url', false );
 		$branch = get_transient( 'gitium_remote_tracking_branch' );
 		
-		error_log( __FUNCTION__ . ' -  $remote_url = ' . $remote_url );
-		error_log( __FUNCTION__ . ' -  $branch = ' . $branch );
+		// error_log( __FUNCTION__ . ' -  $remote_url = ' . $remote_url );
+		// error_log( __FUNCTION__ . ' -  $branch = ' . $branch );
 
 		if ( $remote_url && $branch ) {
 			$git->init();
@@ -71,13 +71,13 @@ function gitium_auto_init( ) {
 			$current_user = wp_get_current_user();
 			$commit = $git->commit( __( 'Merged existing code from ', 'gitium' ) . get_home_url(), $current_user->display_name, $current_user->user_email );
 			if ( ! $commit ) {
-				$git->cleanup();
-				error_log( __FUNCTION__ . ' -  Error commiting existing code' );
+				//$git->cleanup();
+				error_log( __FUNCTION__ . ' -  Error commiting existing code: ' . $git->get_last_error() );
 				return;
 			}
 			if ( ! $git->merge_initial_commit( $commit, $branch ) ) {
-				error_log( __FUNCTION__ . ' -  Error merging existing code' );
-				$git->cleanup();
+				error_log( __FUNCTION__ . ' -  Error merging existing code: ' . $git->get_last_error());
+				//$git->cleanup();
 				return;
 			}
 			$git->push( $branch );		

--- a/gitium/gitium.php
+++ b/gitium/gitium.php
@@ -78,7 +78,7 @@ function gitium_deactivation() {
 }
 register_deactivation_hook( __FILE__, 'gitium_deactivation' );
 
-function gitium_uninstall_hook() {
+function gitium_uninstall_hook( $delete_options = true ) {
 	delete_transient( 'gitium_remote_tracking_branch' );
 	delete_transient( 'gitium_remote_disconnected' );
 	delete_transient( 'gitium_uncommited_changes' );
@@ -87,8 +87,10 @@ function gitium_uninstall_hook() {
 	delete_transient( 'gitium_menu_bubble' );
 	delete_transient( 'gitium_is_status_working' );
 
-	delete_option( 'gitium_keypair' );
-	delete_option( 'gitium_webhook_key' );
+	if ( $delete_options ) {
+		delete_option( 'gitium_keypair' );
+		delete_option( 'gitium_webhook_key' );	
+	}
 }
 register_uninstall_hook( __FILE__, 'gitium_uninstall_hook' );
 

--- a/gitium/gitium.php
+++ b/gitium/gitium.php
@@ -72,11 +72,11 @@ function gitium_auto_init( ) {
 			$commit = $git->commit( __( 'Merged existing code from ', 'gitium' ) . get_home_url(), $current_user->display_name, $current_user->user_email );
 			if ( ! $commit ) {
 				//$git->cleanup();
-				error_log( __FUNCTION__ . ' -  Error commiting existing code: ' . $git->get_last_error() );
+				//error_log( __FUNCTION__ . ' -  Error commiting existing code: ' . $git->get_last_error() );
 				return;
 			}
 			if ( ! $git->merge_initial_commit( $commit, $branch ) ) {
-				error_log( __FUNCTION__ . ' -  Error merging existing code: ' . $git->get_last_error());
+				//error_log( __FUNCTION__ . ' -  Error merging existing code: ' . $git->get_last_error());
 				//$git->cleanup();
 				return;
 			}

--- a/gitium/inc/class-git-wrapper.php
+++ b/gitium/inc/class-git-wrapper.php
@@ -231,8 +231,12 @@ class Git_Wrapper {
 	}
 
 	function init() {
-		file_put_contents( "$this->repo_dir/.gitignore", $this->gitignore );
-		list( $return, ) = $this->_call( 'init' );
+		if( ! file_exists( "$this->repo_dir/.gitignore" ) ) {
+			file_put_contents( "$this->repo_dir/.gitignore", $this->gitignore );
+		}
+		if( ! $this->is_dot_git_dir( "$this->repo_dir/.git" ) ) {
+			list( $return, ) = $this->_call( 'init' );
+		}
 		$this->_call( 'config', 'user.email', 'gitium@presslabs.com' );
 		$this->_call( 'config', 'user.name', 'Gitium' );
 		$this->_call( 'config', 'push.default', 'matching' );

--- a/gitium/inc/class-git-wrapper.php
+++ b/gitium/inc/class-git-wrapper.php
@@ -242,6 +242,9 @@ class Git_Wrapper {
 	}
 
 	function init() {
+		if( file_exists( "$this->repo_dir/.gitignore_gitium" ) ) {
+			copy("$this->repo_dir/.gitignore_gitium", "$this->repo_dir/.gitignore");
+		}
 		if( ! file_exists( "$this->repo_dir/.gitignore" ) ) {
 			file_put_contents( "$this->repo_dir/.gitignore", $this->gitignore );
 		}

--- a/gitium/inc/class-git-wrapper.php
+++ b/gitium/inc/class-git-wrapper.php
@@ -84,6 +84,17 @@ wp-includes/
 /wp-signup.php
 /wp-trackback.php
 /xmlrpc.php
+
+.heroku/
+.profile.d/
+vendor/
+.composer/
+.builders_run
+.bash_history
+.rnd
+.release
+.env
+
 EOF
 );
 

--- a/gitium/inc/class-gitium-menu.php
+++ b/gitium/inc/class-gitium-menu.php
@@ -65,7 +65,7 @@ class Gitium_Menu {
 			return;
 		}
 		check_admin_referer( 'gitium-admin' );
-		gitium_uninstall_hook();
+		gitium_uninstall_hook(false);
 		if ( ! $this->git->remove_remote() ) {
 			$this->redirect( 'Could not remove remote.' );
 		}

--- a/gitium/inc/class-gitium-submenu-configure.php
+++ b/gitium/inc/class-gitium-submenu-configure.php
@@ -89,6 +89,11 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 
 	public function init_repo() {
 		$remote_url = filter_input(INPUT_POST, 'remote_url', FILTER_SANITIZE_STRING);
+		if ( empty( $remote_url ) ) {
+			$remote_url = get_option( 'gitium_remote_url', '' );
+		} elseif ( $remote_url != get_option( 'gitium_remote_url', '' ) ) {
+			update_option( 'gitium_remote_url', $remote_url);
+		}
 	    $gitium_submit_fetch = filter_input(INPUT_POST, 'GitiumSubmitFetch', FILTER_SANITIZE_STRING);
 		if ( ! isset( $gitium_submit_fetch ) || ! isset( $remote_url ) ) {
 			return;
@@ -133,11 +138,12 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 	}
 
 	private function setup_step_1_remote_url() {
+		$remote_url = get_option( 'gitium_remote_url', "" );
 		?>
 		<tr>
 		<th scope="row"><label for="remote_url"><?php _e( 'Remote URL', 'gitium' ); ?></label></th>
 			<td>
-				<input type="text" class="regular-text" name="remote_url" id="remote_url" placeholder="git@github.com:user/example.git" value="">
+				<input type="text" class="regular-text" name="remote_url" id="remote_url" placeholder="git@github.com:user/example.git" value="<?php echo esc_attr( $remote_url ); ?>">
 				<p class="description"><?php _e( 'This URL provide access to a Git repository via SSH, HTTPS, or Subversion.', 'gitium' ); ?><br />
 		<?php _e( 'If you need to authenticate over "https://" instead of SSH use: <code>https://user:pass@github.com/user/example.git</code>', 'gitium' ); ?></p>
 			</td>

--- a/gitium/inc/class-gitium-submenu-configure.php
+++ b/gitium/inc/class-gitium-submenu-configure.php
@@ -89,9 +89,7 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 
 	public function init_repo() {
 		$remote_url = filter_input(INPUT_POST, 'remote_url', FILTER_SANITIZE_STRING);
-		if ( empty( $remote_url ) ) {
-			$remote_url = get_option( 'gitium_remote_url', '' );
-		} elseif ( $remote_url != get_option( 'gitium_remote_url', '' ) ) {
+		if ( $remote_url != get_option( 'gitium_remote_url', '' ) ) {
 			update_option( 'gitium_remote_url', $remote_url);
 		}
 	    $gitium_submit_fetch = filter_input(INPUT_POST, 'GitiumSubmitFetch', FILTER_SANITIZE_STRING);

--- a/gitium/inc/class-gitium-submenu-configure.php
+++ b/gitium/inc/class-gitium-submenu-configure.php
@@ -91,6 +91,7 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 		$remote_url = filter_input(INPUT_POST, 'remote_url', FILTER_SANITIZE_STRING);
 		if ( $remote_url != get_option( 'gitium_remote_url', '' ) ) {
 			update_option( 'gitium_remote_url', $remote_url);
+			error_log( __FUNCTION__ . ' -  $remote_url = ' . $remote_url );
 		}
 	    $gitium_submit_fetch = filter_input(INPUT_POST, 'GitiumSubmitFetch', FILTER_SANITIZE_STRING);
 		if ( ! isset( $gitium_submit_fetch ) || ! isset( $remote_url ) ) {

--- a/gitium/inc/ssh-git
+++ b/gitium/inc/ssh-git
@@ -1,6 +1,12 @@
 #!/bin/sh
 SSH_AUTH_SOCK=''
 SSH="ssh -q -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+if [ "$GIT_SSH_KEY" ] ; then
+    echo "$GIT_SSH_KEY" > /tmp/gitium.key
+    export GIT_KEY_FILE="/tmp/gitium.key"
+fi
+
 if [ -z "$GIT_KEY_FILE" ] ; then
     exec $SSH "$@"
 else


### PR DESCRIPTION
First of all, thanks for sharing this excellent plugin.

The reason for this PR is that Gitium, as it is now, is not Heroku/Dokku friendly for the following reasons:

1) It assumes that only wp-contents should be versioned. However herokuish platforms rely on all the code of an app being available at the time you push. In addition, there is no clear advantage on having wp-core separated from wp-contents.

2) It assumes that the remote repo URL won't be available until someone visits the admin panel and writes it down. In a herokuish platform, the remote repo would be defined in a linked database or an environment variable.

3) It doesn't automatically initialize and connect to the remote repository, relying on a person to visit the admin page and following the step-by-step setup procedure. In herokuish platforms, you would expect your app to be fully working after doing "git push".

4) It automatically regenerates the SSH keys and webhooks when you manually disconnect from the repo. This is not strictly a problem with herokuish platforms, but looks unnecessary and a bit annoying.