### PR TITLE
Custom GITIGNORE 

### DIFF
--- a/gitium/inc/class-git-wrapper.php
+++ b/gitium/inc/class-git-wrapper.php
@@ -15,7 +15,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-define('GITIGNORE', <<<EOF
+if (!defined('GITIGNORE'))
+    define('GITIGNORE', <<<EOF
 *.log
 *.swp
 *.back


### PR DESCRIPTION
We set the GITIGNORE constant in order to have a custom initial configuration. A simple check like this will make sure there are no warnings in the php error log.