### PR TITLE
replace filter sanitize string because is deprecated in PHP 8.1

### DIFF
--- a/gitium/functions.php
+++ b/gitium/functions.php
@@ -193,7 +193,7 @@ function gitium_group_commit_modified_plugins_and_themes( $msg_append = '' ) {
 	}
 
 	foreach ( $commit_groups as $base_path => $change ) {
-		$commit_message = _gitium_format_message( $change['name'], $change['version'], "${change['action']} ${change['type']}" );
+		$commit_message = _gitium_format_message( $change['name'], $change['version'], "{$change['action']} {$change['type']}" );
 		$commit = _gitium_commit_changes( "$commit_message $msg_append", $base_path, false );
 		if ( $commit ) {
 			$commits[] = $commit;

--- a/gitium/gitium-webhook.php
+++ b/gitium/gitium-webhook.php
@@ -18,14 +18,14 @@
 header( 'Content-Type: text/html' );
 define( 'SHORTINIT', true );
 //$wordpress_loader = $_SERVER['DOCUMENT_ROOT'] . '/wp-load.php';
-$wordpress_loader = filter_input(INPUT_SERVER, 'DOCUMENT_ROOT', FILTER_SANITIZE_STRING) . '/wp-load.php';
+$wordpress_loader = filter_input(INPUT_SERVER, 'DOCUMENT_ROOT', FILTER_SANITIZE_FULL_SPECIAL_CHARS) . '/wp-load.php';
 
 require_once $wordpress_loader;
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/inc/class-git-wrapper.php';
 
 $webhook_key = get_option( 'gitium_webhook_key', '' );
-$get_key = filter_input(INPUT_GET, 'key', FILTER_SANITIZE_STRING);
+$get_key = filter_input(INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 if ( ! empty ( $webhook_key ) && isset( $get_key ) && $webhook_key == $get_key ) :
 	( '1.7' <= substr( $git->get_version(), 0, 3 ) ) or wp_die( 'Gitium plugin require minimum `git version 1.7`!' );
 

--- a/gitium/inc/class-git-wrapper.php
+++ b/gitium/inc/class-git-wrapper.php
@@ -165,7 +165,7 @@ class Git_Wrapper {
 		$env      = $this->get_env();
 
 		$git_bin_path = apply_filters( 'gitium_git_bin_path', '' );
-		$cmd = "${git_bin_path}git $args 2>&1";
+		$cmd = "{$git_bin_path}git $args 2>&1";
 
 		$proc = proc_open(
 			$cmd,

--- a/gitium/inc/class-gitium-menu.php
+++ b/gitium/inc/class-gitium-menu.php
@@ -59,7 +59,7 @@ class Gitium_Menu {
 	}
 
 	public function disconnect_repository() {
-        $gitium_disconnect_repo = filter_input(INPUT_POST, 'GitiumSubmitDisconnectRepository', FILTER_SANITIZE_STRING);
+        $gitium_disconnect_repo = filter_input(INPUT_POST, 'GitiumSubmitDisconnectRepository', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 
 		if ( ! isset( $gitium_disconnect_repo ) ) {
 			return;
@@ -73,8 +73,8 @@ class Gitium_Menu {
 	}
 
 	public function show_message() {
-	    $get_message = filter_input(INPUT_GET, 'message', FILTER_SANITIZE_STRING);
-	    $get_success = filter_input(INPUT_GET, 'success', FILTER_SANITIZE_STRING);
+	    $get_message = filter_input(INPUT_GET, 'message', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+	    $get_success = filter_input(INPUT_GET, 'success', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( isset( $get_message ) && $get_message ) {
 			$type    = ( isset( $get_success ) && $get_success == 1 ) ? 'updated' : 'error';
 			$message = get_transient( 'message_'. $get_message );

--- a/gitium/inc/class-gitium-submenu-configure.php
+++ b/gitium/inc/class-gitium-submenu-configure.php
@@ -52,7 +52,7 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 	}
 
 	public function regenerate_keypair() {
-	    $submit_keypair = filter_input(INPUT_POST, 'GitiumSubmitRegenerateKeypair', FILTER_SANITIZE_STRING);
+	    $submit_keypair = filter_input(INPUT_POST, 'GitiumSubmitRegenerateKeypair', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $submit_keypair ) ) {
 			return;
 		}
@@ -62,7 +62,7 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 	}
 
 	public function gitium_warning() {
-		$submit_warning = filter_input(INPUT_POST, 'GitiumSubmitWarning', FILTER_SANITIZE_STRING);
+		$submit_warning = filter_input(INPUT_POST, 'GitiumSubmitWarning', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $submit_warning ) ) {
 			return;
 		}
@@ -88,8 +88,8 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 	}
 
 	public function init_repo() {
-		$remote_url = filter_input(INPUT_POST, 'remote_url', FILTER_SANITIZE_STRING);
-	    $gitium_submit_fetch = filter_input(INPUT_POST, 'GitiumSubmitFetch', FILTER_SANITIZE_STRING);
+		$remote_url = filter_input(INPUT_POST, 'remote_url', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+	    $gitium_submit_fetch = filter_input(INPUT_POST, 'GitiumSubmitFetch', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $gitium_submit_fetch ) || ! isset( $remote_url ) ) {
 			return;
 		}
@@ -107,8 +107,8 @@ class Gitium_Submenu_Configure extends Gitium_Menu {
 	}
 
 	public function choose_branch() {
-	    $gitium_submit_merge_push = filter_input(INPUT_POST, 'GitiumSubmitMergeAndPush', FILTER_SANITIZE_STRING);
-        $tracking_branch = filter_input(INPUT_POST, 'tracking_branch', FILTER_SANITIZE_STRING);
+	    $gitium_submit_merge_push = filter_input(INPUT_POST, 'GitiumSubmitMergeAndPush', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        $tracking_branch = filter_input(INPUT_POST, 'tracking_branch', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $gitium_submit_merge_push ) || ! isset( $tracking_branch ) ) {
 			return;
 		}

--- a/gitium/inc/class-gitium-submenu-settings.php
+++ b/gitium/inc/class-gitium-submenu-settings.php
@@ -38,7 +38,7 @@ class Gitium_Submenu_Settings extends Gitium_Menu {
 	}
 
 	public function regenerate_webhook() {
-		$gitium_regen_webhook = filter_input(INPUT_POST, 'GitiumSubmitRegenerateWebhook', FILTER_SANITIZE_STRING);
+		$gitium_regen_webhook = filter_input(INPUT_POST, 'GitiumSubmitRegenerateWebhook', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $gitium_regen_webhook ) ) {
 			return;
 		}
@@ -48,7 +48,7 @@ class Gitium_Submenu_Settings extends Gitium_Menu {
 	}
 
 	public function regenerate_public_key() {
-		$submit_regenerate_pub_key = filter_input(INPUT_POST, 'GitiumSubmitRegeneratePublicKey', FILTER_SANITIZE_STRING);
+		$submit_regenerate_pub_key = filter_input(INPUT_POST, 'GitiumSubmitRegeneratePublicKey', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $submit_regenerate_pub_key ) ) {
 			return;
 		}
@@ -99,8 +99,8 @@ class Gitium_Submenu_Settings extends Gitium_Menu {
 	}
 
 	public function save() {
-	    $submit_save = filter_input(INPUT_POST, 'GitiumSubmitSave', FILTER_SANITIZE_STRING);
-	    $gitignore_content = filter_input(INPUT_POST, 'gitignore_content', FILTER_SANITIZE_STRING);
+	    $submit_save = filter_input(INPUT_POST, 'GitiumSubmitSave', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+	    $gitignore_content = filter_input(INPUT_POST, 'gitignore_content', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $submit_save ) || ! isset( $gitignore_content ) ) {
 			return;
 		}

--- a/gitium/inc/class-gitium-submenu-status.php
+++ b/gitium/inc/class-gitium-submenu-status.php
@@ -77,7 +77,7 @@ class Gitium_Submenu_Status extends Gitium_Menu {
 	}
 
 	public function save_ignorelist() {
-	    $gitium_ignore_path = filter_input(INPUT_POST, 'GitiumIgnorePath', FILTER_SANITIZE_STRING);
+	    $gitium_ignore_path = filter_input(INPUT_POST, 'GitiumIgnorePath', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		if ( ! isset( $gitium_ignore_path ) ) {
 			return;
 		} else {
@@ -94,8 +94,8 @@ class Gitium_Submenu_Status extends Gitium_Menu {
 	}
 
 	public function save_changes() {
-	    $gitium_save_changes = filter_input(INPUT_POST, 'GitiumSubmitSaveChanges', FILTER_SANITIZE_STRING);
-		$gitium_commit_msg = filter_input(INPUT_POST, 'commitmsg', FILTER_SANITIZE_STRING);
+	    $gitium_save_changes = filter_input(INPUT_POST, 'GitiumSubmitSaveChanges', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$gitium_commit_msg = filter_input(INPUT_POST, 'commitmsg', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 	    if ( ! isset( $gitium_save_changes ) ) {
 			return;
 		}


### PR DESCRIPTION
https://teamtreehouse.com/community/can-we-use-filtersanitizespecialchars-instead-of-filtersanitizestring-for-msg#:~:text=FILTER_SANITIZE_SPECIAL_CHARS%20will%20leave%20the%20tags,just%20text%20inside%20the%20tags.

https://www.w3schools.com/php/filter_sanitize_string.asp

We need to check as well if it's okay to use the new filter.